### PR TITLE
[Bug Fix] Added missing required categories for Tentacle Clipping recipe

### DIFF
--- a/recipes/medicaltable1/ocrawtentaplant.recipe
+++ b/recipes/medicaltable1/ocrawtentaplant.recipe
@@ -7,5 +7,5 @@
     "item" : "ocrawtentaplant",
     "count" : 1
   },
-  "groups" : [ "craftingmedical" ]
+  "groups" : [ "craftingmedical", "buffs", "all" ]
 }


### PR DESCRIPTION
Puts recipe in the second tab ("buffs") along with the preexisting ink vials. If intended to be in the first tab, change "buffs" to "healing".